### PR TITLE
Specify version constraints for build dependencies. Fixes #19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.2.2 (Next)
 
 * Your contribution here.
+* [#17](https://github.com/dblock/fue/issues/19): Fix open-ended dependencies in gemspec - [@SYNstack](https://github.com/synstack).
 
 ### 0.2.1 (2018/8/23)
 

--- a/fue.gemspec
+++ b/fue.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.homepage = 'http://github.com/dblock/fue'
   s.licenses = ['MIT']
   s.summary = 'Find an e-mail address of a Github user.'
-  s.add_dependency 'github_api'
-  s.add_dependency 'gli'
+  s.add_dependency 'github_api', '~> 0.18.2'
+  s.add_dependency 'gli', '~> 2.17'
   s.add_dependency 'graphlient', '~> 0.3.2'
 end


### PR DESCRIPTION
Fixes `WARNING:  open-ended dependency on gli (>= 0) is not recommended` etc.

Please let me know if there is a more consistent style you'd like for PRs/commits/issues, I'm new to this :)