### PR TITLE
Migrate Danger to use danger-pr-comment workflow.

### DIFF
--- a/.github/workflows/danger-comment.yml
+++ b/.github/workflows/danger-comment.yml
@@ -1,0 +1,11 @@
+name: Danger Comment
+
+on:
+  workflow_run:
+    workflows: [Danger]
+    types: [completed]
+
+jobs:
+  comment:
+    uses: numbata/danger-pr-comment/.github/workflows/danger-comment.yml@v0.1.0
+    secrets: inherit

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,19 +1,13 @@
-name: PR Linter
-on: [pull_request]
+name: Danger
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+
 jobs:
   danger:
-    runs-on: ubuntu-latest
-    env:
-      BUNDLE_GEMFILE: ${{ github.workspace }}/Gemfile.danger
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 3.3.6
-          bundler-cache: true
-      - run: |
-          # the personal token is public, this is ok, base64 encode to avoid tripping Github
-          TOKEN=$(echo -n Z2hwX0xNQ3VmanBFeTBvYkZVTWh6NVNqVFFBOEUxU25abzBqRUVuaAo= | base64 --decode)
-          DANGER_GITHUB_API_TOKEN=$TOKEN bundle exec danger --verbose
+    uses: numbata/danger-pr-comment/.github/workflows/danger-run.yml@v0.1.0
+    secrets: inherit
+    with:
+      ruby-version: '3.4'
+      bundler-cache: true

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -8,6 +8,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3.6
+          ruby-version: 3.4.1
           bundler-cache: true
       - run: bundle exec rubocop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - 3.3.6
+          - 3.4.1
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.6.0 (Next)
 
+* [#38](https://github.com/dblock/fue/pull/38): Migrate Danger to use danger-pr-comment workflow - [@dblock](https://github.com/dblock).
 * [#37](https://github.com/dblock/fue/pull/36): Added fetching of e-mails from `Signed-off-by` and `--[no-]signed-off-by` - [@dblock](https://github.com/dblock).
 * [#36](https://github.com/dblock/fue/pull/36): Added `--[no-]reply` to exclude `@users.noreply.github.com` email addresses - [@dblock](https://github.com/dblock).
 * Your contribution here.

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
-toc.check!
+danger.import_dangerfile(gem: 'danger-pr-comment')
+
 changelog.check!
+toc.check!

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,10 @@ source 'http://rubygems.org'
 gemspec
 
 group :development, :test do
+  gem 'danger', require: false
+  gem 'danger-changelog', require: false
+  gem 'danger-pr-comment', require: false
+  gem 'danger-toc', require: false
   gem 'rake'
   gem 'recursive-open-struct'
   gem 'rspec'

--- a/Gemfile.danger
+++ b/Gemfile.danger
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-group :test do
-  gem 'danger-changelog', '~> 0.6.1'
-  gem 'danger-toc', '~> 0.2.0', require: false
-end


### PR DESCRIPTION
Migrates Danger to use the reusable danger-pr-comment workflow.

## Changes
- Added danger-pr-comment gem v0.1.0
- Updated Gemfile to include danger, danger-changelog, danger-pr-comment, danger-toc gems
- Updated Dangerfile to use danger-pr-comment and added changelog.check! and toc.check!
- Updated .github/workflows/danger.yml to use danger-pr-comment reusable workflow
- Created .github/workflows/danger-comment.yml for PR comment posting
- Removed Gemfile.danger
- Updated all CI workflows to use Ruby 3.4.1

Follows the pattern from:
- https://github.com/slack-ruby/slack-ruby-client/pull/581
- https://github.com/slack-ruby/slack-ruby-bot-server/pull/181